### PR TITLE
Added more HTTP 1.0 response header elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Web++](https://raw.github.com/konteck/wpp/master/logo.png)
-[![Build Status](https://secure.travis-ci.org/konteck/wpp.png)](http://travis-ci.org/konteck/wpp)
+[![Build Status](https://secure.travis-ci.org/mmaraya/wpp.png)](http://travis-ci.org/mmaraya/wpp)
 
 *Single file embedded C++ web server* 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Web++](https://raw.github.com/konteck/wpp/master/logo.png)
-[![Build Status](https://secure.travis-ci.org/mmaraya/wpp.png)](http://travis-ci.org/mmaraya/wpp)
+[![Build Status](https://secure.travis-ci.org/konteck/wpp.png)](http://travis-ci.org/konteck/wpp)
 
 *Single file embedded C++ web server* 
 


### PR DESCRIPTION
I reviewed http://www.rfc-base.org/txt/rfc-1945.txt and made the following changes:
- [x] Added Reason-Phrase ("OK", "Not Found") to the Status Line
- [x] Added Date

The current response header is:

```
HTTP/1.0 200
Server: Web++ 1.0.1
Content-Type: text/html
Content-Length: 5 
```

With this change, the response header will be:

```
HTTP/1.0 200 OK
Server: Web++ 1.0.1
Date: Tue, 31 Dec 2013 04:37:56 UTC
Content-Type: text/html
Content-Length: 5 
```
